### PR TITLE
chamada para tags

### DIFF
--- a/axe/single.php
+++ b/axe/single.php
@@ -187,7 +187,7 @@ function gera_single($caminho, $force=false, $preview=false,$contaitems=1000) {
 		if (gravaarquivohtml($nome,$single,$force,$preview)) {
 			if (isset($POST['POSTID'])) criasymlink($nome,$POST['POSTID']);
 			if (!$preview) criafonteeditavel($nome,$force,$preview);
-			if (true===$quickrebuild) { // não terá rebuild imediato, portanto atualiza já as tags afetadas 
+			if (true!=$quickrebuild) { // não terá rebuild imediato, portanto atualiza já as tags afetadas 
 				foreach(explode(",",$POST['POSTTAGS']) as $tag) {
 					if (strlen(trim($tag))>0) cria_tagindex($tag);
 				}			


### PR DESCRIPTION
Correção na condição do if que chamava a criação de paginas de tags.
Anteriormente, só chamava a função para checagem das tags se fosse um quickrebuild, o que não faz sentido do meu ponto de vista.